### PR TITLE
feat: add multiple boards support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Board data now stored per-board (`kanbeasy:board:<id>`) instead of single key
 - Card number counter moved to global board index for cross-board uniqueness
 - Export reads from active board's storage key
+- New boards created via "+" button start with empty columns instead of example cards
+- `nextCardNumber` in BoardsProvider is now reactive state (was a non-reactive ref)
+- `deleteBoard` no longer performs side effects inside React setState callback
+- Export utility uses `getFromStorage` instead of manual JSON parsing
 
 ## [1.32.7]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Multiple boards support: create, switch, rename, duplicate, and delete boards
+- Board tab bar below the header for quick board switching
+- Right-click context menu on board tabs for rename/duplicate/delete
+- Double-click board tab to rename inline
+- Keyboard shortcuts: Cmd+Shift+[ / Cmd+Shift+] to switch between boards
+- BoardsProvider and BoardsContext for managing board index state
+- Automatic migration from single-board to multi-board storage format
+- `reset()` method on `useUndoableState` for board switching
+- PlusIcon SVG component
 - Card layout editor design document (`docs/card-layout-editor.md`)
+
+### Changed
+
+- Board data now stored per-board (`kanbeasy:board:<id>`) instead of single key
+- Card number counter moved to global board index for cross-board uniqueness
+- Export reads from active board's storage key
 
 ## [1.32.7]
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { Board } from "./components/board/Board";
 import { Header } from "./components/Header";
+import { BoardTabs } from "./components/BoardTabs";
 import { WelcomeModal } from "./components/WelcomeModal";
 import { UndoRedoControls } from "./components/UndoRedoControls";
 import { OwlBuddy } from "./components/OwlBuddy";
@@ -14,6 +15,7 @@ function App() {
     <div className="min-h-screen bg-bg text-text transition-colors">
       <WelcomeModal />
       <Header />
+      <BoardTabs />
       {viewMode === "board" && <Board />}
       {viewMode === "list" && <ListView />}
       {viewMode === "calendar" && <CalendarView />}

--- a/src/__tests__/column-delete.test.tsx
+++ b/src/__tests__/column-delete.test.tsx
@@ -1,6 +1,6 @@
 import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { STORAGE_KEYS } from "../constants/storage";
+import { STORAGE_KEYS, boardStorageKey } from "../constants/storage";
 import { renderApp } from "../test/renderApp";
 import { describe, it, expect, beforeEach } from "vitest";
 
@@ -102,7 +102,9 @@ describe("column delete", () => {
     ).not.toBeInTheDocument();
 
     // Verify cards were archived, not destroyed
-    const stored = JSON.parse(localStorage.getItem(STORAGE_KEYS.BOARD) ?? "{}");
+    const stored = JSON.parse(
+      localStorage.getItem(boardStorageKey("default")) ?? "{}",
+    );
     expect(stored.archive).toHaveLength(1);
     expect(stored.archive[0].title).toBe("New card");
     expect(stored.archive[0].archivedAt).toBeGreaterThan(0);
@@ -155,7 +157,9 @@ describe("column delete", () => {
     ).not.toBeInTheDocument();
 
     // Cards should still be archived even without the warning dialog
-    const stored = JSON.parse(localStorage.getItem(STORAGE_KEYS.BOARD) ?? "{}");
+    const stored = JSON.parse(
+      localStorage.getItem(boardStorageKey("default")) ?? "{}",
+    );
     expect(stored.archive).toHaveLength(1);
   });
 });

--- a/src/board/BoardProvider.tsx
+++ b/src/board/BoardProvider.tsx
@@ -12,7 +12,40 @@ import { useBoards } from "../boards/useBoards";
 
 type LoadResult = { state: BoardState; nextCardNumber: number };
 
-function createInitialBoard(): LoadResult {
+function createEmptyBoard(): LoadResult {
+  const now = Date.now();
+  return {
+    state: {
+      archive: [],
+      columns: [
+        {
+          id: crypto.randomUUID(),
+          title: "To Do",
+          createdAt: now,
+          updatedAt: now,
+          cards: [],
+        },
+        {
+          id: crypto.randomUUID(),
+          title: "In Progress",
+          createdAt: now,
+          updatedAt: now,
+          cards: [],
+        },
+        {
+          id: crypto.randomUUID(),
+          title: "Done",
+          createdAt: now,
+          updatedAt: now,
+          cards: [],
+        },
+      ],
+    },
+    nextCardNumber: 0,
+  };
+}
+
+function createWelcomeBoard(): LoadResult {
   const now = Date.now();
   const todoId = crypto.randomUUID();
   const inProgressId = crypto.randomUUID();
@@ -96,14 +129,18 @@ function createInitialBoard(): LoadResult {
   };
 }
 
-function loadState(storageKey: string, globalCounter: number): LoadResult {
+function loadState(
+  storageKey: string,
+  globalCounter: number,
+  isFirstBoard: boolean,
+): LoadResult {
   const raw =
     typeof window !== "undefined"
       ? window.localStorage.getItem(storageKey)
       : null;
 
   if (raw === null) {
-    return createInitialBoard();
+    return isFirstBoard ? createWelcomeBoard() : createEmptyBoard();
   }
 
   const stored = getFromStorage<{ columns?: unknown; archive?: unknown }>(
@@ -148,18 +185,20 @@ export function BoardProvider({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
   const {
+    boards,
     activeBoardId,
     nextCardNumber: globalCounter,
     setNextCardNumber: setGlobalCounter,
   } = useBoards();
 
   const storageKey = boardStorageKey(activeBoardId);
+  const isFirstBoard = boards.length === 1 && boards[0].id === activeBoardId;
 
   // Track which board we're currently showing
   const currentBoardIdRef = useRef(activeBoardId);
   const loadResult = useRef<LoadResult | null>(null);
   if (loadResult.current === null) {
-    loadResult.current = loadState(storageKey, globalCounter);
+    loadResult.current = loadState(storageKey, globalCounter, isFirstBoard);
   }
 
   const { state, setState, undo, redo, canUndo, canRedo, reset } =
@@ -175,7 +214,7 @@ export function BoardProvider({
     currentBoardIdRef.current = activeBoardId;
 
     const key = boardStorageKey(activeBoardId);
-    const result = loadState(key, globalCounter);
+    const result = loadState(key, globalCounter, false);
     nextCardNumberRef.current = result.nextCardNumber;
     reset(result.state);
   }, [activeBoardId, globalCounter, reset]);

--- a/src/board/BoardProvider.tsx
+++ b/src/board/BoardProvider.tsx
@@ -2,12 +2,13 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import { BoardContext } from "./BoardContext";
 import type { BoardContextValue, BoardState } from "./types";
 import { getFromStorage, saveToStorage } from "../utils/storage";
-import { STORAGE_KEYS } from "../constants/storage";
+import { boardStorageKey } from "../constants/storage";
 import { isArchivedCard, isColumn } from "./validation";
 import { migrateColumnsWithNumbering } from "./migration";
 import { useUndoableState } from "./useUndoableState";
 import { useBoardMutations } from "./useBoardMutations";
 import { useCardSearch } from "./useCardSearch";
+import { useBoards } from "../boards/useBoards";
 
 type LoadResult = { state: BoardState; nextCardNumber: number };
 
@@ -95,12 +96,10 @@ function createInitialBoard(): LoadResult {
   };
 }
 
-function loadState(): LoadResult {
-  // When no board data has ever been saved, seed with example columns.
-  // After "Clear board data", the key exists with { columns: [] }, so we won't re-seed.
+function loadState(storageKey: string, globalCounter: number): LoadResult {
   const raw =
     typeof window !== "undefined"
-      ? window.localStorage.getItem(STORAGE_KEYS.BOARD)
+      ? window.localStorage.getItem(storageKey)
       : null;
 
   if (raw === null) {
@@ -108,14 +107,13 @@ function loadState(): LoadResult {
   }
 
   const stored = getFromStorage<{ columns?: unknown; archive?: unknown }>(
-    STORAGE_KEYS.BOARD,
+    storageKey,
     {},
   );
 
   const cols = Array.isArray(stored.columns)
     ? (stored.columns as unknown[])
         .map((c) => {
-          // migrate legacy columns lacking cards
           if (
             c &&
             typeof c === "object" &&
@@ -135,51 +133,64 @@ function loadState(): LoadResult {
     ? (stored.archive as unknown[]).filter(isArchivedCard)
     : [];
 
-  // Migrate timestamps and assign card numbers
   const { columns, archive, nextCardNumber } = migrateColumnsWithNumbering(
     cols as unknown as Record<string, unknown>[],
     rawArchive as unknown as Record<string, unknown>[],
   );
 
-  // Reconcile with persisted counter (take the max)
-  const persistedCounter = getFromStorage<number>(
-    STORAGE_KEYS.NEXT_CARD_NUMBER,
-    0,
-  );
-
   return {
     state: { columns, archive },
-    nextCardNumber: Math.max(nextCardNumber, persistedCounter),
+    nextCardNumber: Math.max(nextCardNumber, globalCounter),
   };
-}
-
-function saveState(state: BoardState) {
-  saveToStorage(STORAGE_KEYS.BOARD, state);
 }
 
 export function BoardProvider({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
-  // Use lazy init to call loadState once and split state + counter
+  const {
+    activeBoardId,
+    nextCardNumber: globalCounter,
+    setNextCardNumber: setGlobalCounter,
+  } = useBoards();
+
+  const storageKey = boardStorageKey(activeBoardId);
+
+  // Track which board we're currently showing
+  const currentBoardIdRef = useRef(activeBoardId);
   const loadResult = useRef<LoadResult | null>(null);
   if (loadResult.current === null) {
-    loadResult.current = loadState();
+    loadResult.current = loadState(storageKey, globalCounter);
   }
 
-  const { state, setState, undo, redo, canUndo, canRedo } =
+  const { state, setState, undo, redo, canUndo, canRedo, reset } =
     useUndoableState<BoardState>(() => loadResult.current!.state, {
       maxHistory: 50,
     });
 
   const nextCardNumberRef = useRef(loadResult.current.nextCardNumber);
 
-  const saveCounter = useCallback((n: number) => {
-    nextCardNumberRef.current = n;
-    saveToStorage(STORAGE_KEYS.NEXT_CARD_NUMBER, n);
-  }, []);
-
+  // When the active board changes, reload state
   useEffect(() => {
-    saveState(state);
+    if (activeBoardId === currentBoardIdRef.current) return;
+    currentBoardIdRef.current = activeBoardId;
+
+    const key = boardStorageKey(activeBoardId);
+    const result = loadState(key, globalCounter);
+    nextCardNumberRef.current = result.nextCardNumber;
+    reset(result.state);
+  }, [activeBoardId, globalCounter, reset]);
+
+  const saveCounter = useCallback(
+    (n: number) => {
+      nextCardNumberRef.current = n;
+      setGlobalCounter(n);
+    },
+    [setGlobalCounter],
+  );
+
+  // Save board state to its storage key whenever it changes
+  useEffect(() => {
+    saveToStorage(boardStorageKey(currentBoardIdRef.current), state);
   }, [state]);
 
   const mutations = useBoardMutations(setState, nextCardNumberRef, saveCounter);

--- a/src/board/__tests__/archive.integration.test.ts
+++ b/src/board/__tests__/archive.integration.test.ts
@@ -1,11 +1,16 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
+import { BoardsProvider } from "../../boards/BoardsProvider";
 import { BoardProvider } from "../BoardProvider";
 import { useBoard } from "../useBoard";
 
 function wrapper({ children }: { children: ReactNode }) {
-  return createElement(BoardProvider, null, children);
+  return createElement(
+    BoardsProvider,
+    null,
+    createElement(BoardProvider, null, children),
+  );
 }
 
 describe("card archive through BoardProvider", () => {

--- a/src/board/__tests__/clipboard.test.tsx
+++ b/src/board/__tests__/clipboard.test.tsx
@@ -3,15 +3,18 @@ import { describe, it, expect } from "vitest";
 import { useClipboard } from "../useClipboard";
 import { useBoard } from "../useBoard";
 import { ClipboardProvider } from "../ClipboardProvider";
+import { BoardsProvider } from "../../boards/BoardsProvider";
 import { BoardProvider } from "../BoardProvider";
 import type { CardClipboard } from "../types";
 import { STORAGE_KEYS } from "../../constants/storage";
 
 function wrapper({ children }: { children: React.ReactNode }) {
   return (
-    <BoardProvider>
-      <ClipboardProvider>{children}</ClipboardProvider>
-    </BoardProvider>
+    <BoardsProvider>
+      <BoardProvider>
+        <ClipboardProvider>{children}</ClipboardProvider>
+      </BoardProvider>
+    </BoardsProvider>
   );
 }
 

--- a/src/board/__tests__/timestamps.test.ts
+++ b/src/board/__tests__/timestamps.test.ts
@@ -1,11 +1,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
+import { BoardsProvider } from "../../boards/BoardsProvider";
 import { BoardProvider } from "../BoardProvider";
 import { useBoard } from "../useBoard";
 
 function wrapper({ children }: { children: ReactNode }) {
-  return createElement(BoardProvider, null, children);
+  return createElement(
+    BoardsProvider,
+    null,
+    createElement(BoardProvider, null, children),
+  );
 }
 
 describe("timestamps in BoardProvider", () => {

--- a/src/board/__tests__/undoRedo.integration.test.ts
+++ b/src/board/__tests__/undoRedo.integration.test.ts
@@ -1,11 +1,16 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
+import { BoardsProvider } from "../../boards/BoardsProvider";
 import { BoardProvider } from "../BoardProvider";
 import { useBoard } from "../useBoard";
 
 function wrapper({ children }: { children: ReactNode }) {
-  return createElement(BoardProvider, null, children);
+  return createElement(
+    BoardsProvider,
+    null,
+    createElement(BoardProvider, null, children),
+  );
 }
 
 describe("undo/redo through BoardProvider", () => {

--- a/src/board/__tests__/useUndoableState.test.ts
+++ b/src/board/__tests__/useUndoableState.test.ts
@@ -110,6 +110,31 @@ describe("useUndoableState", () => {
     expect(result.current.state).toBe("x");
   });
 
+  it("reset replaces state and clears history", () => {
+    const { result } = renderHook(() => useUndoableState(0));
+    act(() => result.current.setState(1));
+    act(() => result.current.setState(2));
+    expect(result.current.canUndo).toBe(true);
+
+    act(() => result.current.reset(99));
+
+    expect(result.current.state).toBe(99);
+    expect(result.current.canUndo).toBe(false);
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  it("reset clears redo stack", () => {
+    const { result } = renderHook(() => useUndoableState(0));
+    act(() => result.current.setState(1));
+    act(() => result.current.undo());
+    expect(result.current.canRedo).toBe(true);
+
+    act(() => result.current.reset(50));
+
+    expect(result.current.state).toBe(50);
+    expect(result.current.canRedo).toBe(false);
+  });
+
   it("does not track history when disabled", () => {
     const { result } = renderHook(() =>
       useUndoableState(0, { enabled: false }),

--- a/src/board/useUndoableState.ts
+++ b/src/board/useUndoableState.ts
@@ -18,6 +18,7 @@ type UseUndoableStateReturn<T> = {
   redo: () => void;
   canUndo: boolean;
   canRedo: boolean;
+  reset: (newState: T) => void;
 };
 
 export function useUndoableState<T>(
@@ -90,8 +91,20 @@ export function useUndoableState<T>(
     });
   }, []);
 
+  const reset = useCallback((newState: T) => {
+    setHistory({ past: [], present: newState, future: [] });
+  }, []);
+
   const canUndo = enabled && history.past.length > 0;
   const canRedo = enabled && history.future.length > 0;
 
-  return { state: history.present, setState, undo, redo, canUndo, canRedo };
+  return {
+    state: history.present,
+    setState,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
+    reset,
+  };
 }

--- a/src/boards/BoardsContext.tsx
+++ b/src/boards/BoardsContext.tsx
@@ -1,0 +1,6 @@
+import { createContext } from "react";
+import type { BoardsContextValue } from "./types";
+
+export const BoardsContext = createContext<BoardsContextValue | undefined>(
+  undefined,
+);

--- a/src/boards/BoardsProvider.tsx
+++ b/src/boards/BoardsProvider.tsx
@@ -1,0 +1,213 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { BoardsContext } from "./BoardsContext";
+import type { BoardIndex, BoardMeta } from "./types";
+import { STORAGE_KEYS, boardStorageKey } from "../constants/storage";
+import { getFromStorage, saveToStorage } from "../utils/storage";
+
+const DEFAULT_BOARD_ID = "default";
+
+function createDefaultIndex(): BoardIndex {
+  const now = new Date().toISOString();
+  return {
+    boards: [
+      {
+        id: DEFAULT_BOARD_ID,
+        title: "My Board",
+        createdAt: now,
+        updatedAt: now,
+      },
+    ],
+    activeBoardId: DEFAULT_BOARD_ID,
+    nextCardNumber: 0,
+  };
+}
+
+function migrateFromSingleBoard(): BoardIndex | null {
+  if (typeof window === "undefined") return null;
+
+  const existingBoard = window.localStorage.getItem(STORAGE_KEYS.BOARD);
+  if (existingBoard === null) return null;
+
+  // Move existing board data to the new keyed format
+  window.localStorage.setItem(boardStorageKey(DEFAULT_BOARD_ID), existingBoard);
+  window.localStorage.removeItem(STORAGE_KEYS.BOARD);
+
+  // Read existing card counter
+  const counterRaw = window.localStorage.getItem(STORAGE_KEYS.NEXT_CARD_NUMBER);
+  const counter = counterRaw ? Number(counterRaw) : 0;
+  window.localStorage.removeItem(STORAGE_KEYS.NEXT_CARD_NUMBER);
+
+  const now = new Date().toISOString();
+  const index: BoardIndex = {
+    boards: [
+      {
+        id: DEFAULT_BOARD_ID,
+        title: "My Board",
+        createdAt: now,
+        updatedAt: now,
+      },
+    ],
+    activeBoardId: DEFAULT_BOARD_ID,
+    nextCardNumber: counter,
+  };
+
+  saveToStorage(STORAGE_KEYS.BOARD_INDEX, index);
+  return index;
+}
+
+function loadIndex(): BoardIndex {
+  const stored = getFromStorage<BoardIndex | null>(
+    STORAGE_KEYS.BOARD_INDEX,
+    null,
+  );
+  if (stored && Array.isArray(stored.boards) && stored.boards.length > 0) {
+    return stored;
+  }
+
+  // Try migrating from single-board format
+  const migrated = migrateFromSingleBoard();
+  if (migrated) return migrated;
+
+  // Brand new user
+  const fresh = createDefaultIndex();
+  saveToStorage(STORAGE_KEYS.BOARD_INDEX, fresh);
+  return fresh;
+}
+
+export function BoardsProvider({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  const indexRef = useRef<BoardIndex | null>(null);
+  if (indexRef.current === null) {
+    indexRef.current = loadIndex();
+  }
+
+  const [boards, setBoards] = useState<BoardMeta[]>(indexRef.current.boards);
+  const [activeBoardId, setActiveBoardId] = useState<string>(
+    indexRef.current.activeBoardId,
+  );
+  const nextCardNumberRef = useRef(indexRef.current.nextCardNumber);
+
+  // Persist index whenever boards or activeBoardId change
+  useEffect(() => {
+    const index: BoardIndex = {
+      boards,
+      activeBoardId,
+      nextCardNumber: nextCardNumberRef.current,
+    };
+    saveToStorage(STORAGE_KEYS.BOARD_INDEX, index);
+  }, [boards, activeBoardId]);
+
+  const setNextCardNumber = useCallback(
+    (n: number) => {
+      nextCardNumberRef.current = n;
+      const index: BoardIndex = {
+        boards,
+        activeBoardId,
+        nextCardNumber: n,
+      };
+      saveToStorage(STORAGE_KEYS.BOARD_INDEX, index);
+    },
+    [boards, activeBoardId],
+  );
+
+  const createBoard = useCallback((title: string): string => {
+    const id = crypto.randomUUID();
+    const now = new Date().toISOString();
+    const meta: BoardMeta = {
+      id,
+      title,
+      createdAt: now,
+      updatedAt: now,
+    };
+    setBoards((prev) => [...prev, meta]);
+    setActiveBoardId(id);
+    return id;
+  }, []);
+
+  const deleteBoard = useCallback(
+    (id: string) => {
+      setBoards((prev) => {
+        if (prev.length <= 1) return prev;
+        const next = prev.filter((b) => b.id !== id);
+        if (next.length === prev.length) return prev;
+
+        // Clean up board data from localStorage
+        window.localStorage.removeItem(boardStorageKey(id));
+
+        // If deleting the active board, switch to the first remaining
+        if (id === activeBoardId) {
+          setActiveBoardId(next[0].id);
+        }
+        return next;
+      });
+    },
+    [activeBoardId],
+  );
+
+  const renameBoard = useCallback((id: string, title: string) => {
+    setBoards((prev) =>
+      prev.map((b) =>
+        b.id === id ? { ...b, title, updatedAt: new Date().toISOString() } : b,
+      ),
+    );
+  }, []);
+
+  const switchBoard = useCallback((id: string) => {
+    setActiveBoardId(id);
+  }, []);
+
+  const duplicateBoard = useCallback((id: string, title: string): string => {
+    const newId = crypto.randomUUID();
+    const now = new Date().toISOString();
+    const meta: BoardMeta = {
+      id: newId,
+      title,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    // Copy board data
+    const sourceData = window.localStorage.getItem(boardStorageKey(id));
+    if (sourceData) {
+      window.localStorage.setItem(boardStorageKey(newId), sourceData);
+    }
+
+    setBoards((prev) => {
+      const sourceIndex = prev.findIndex((b) => b.id === id);
+      const next = [...prev];
+      next.splice(sourceIndex + 1, 0, meta);
+      return next;
+    });
+    setActiveBoardId(newId);
+    return newId;
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      boards,
+      activeBoardId,
+      nextCardNumber: nextCardNumberRef.current,
+      createBoard,
+      deleteBoard,
+      renameBoard,
+      switchBoard,
+      duplicateBoard,
+      setNextCardNumber,
+    }),
+    [
+      boards,
+      activeBoardId,
+      createBoard,
+      deleteBoard,
+      renameBoard,
+      switchBoard,
+      duplicateBoard,
+      setNextCardNumber,
+    ],
+  );
+
+  return (
+    <BoardsContext.Provider value={value}>{children}</BoardsContext.Provider>
+  );
+}

--- a/src/boards/BoardsProvider.tsx
+++ b/src/boards/BoardsProvider.tsx
@@ -86,30 +86,15 @@ export function BoardsProvider({
   const [activeBoardId, setActiveBoardId] = useState<string>(
     indexRef.current.activeBoardId,
   );
-  const nextCardNumberRef = useRef(indexRef.current.nextCardNumber);
-
-  // Persist index whenever boards or activeBoardId change
-  useEffect(() => {
-    const index: BoardIndex = {
-      boards,
-      activeBoardId,
-      nextCardNumber: nextCardNumberRef.current,
-    };
-    saveToStorage(STORAGE_KEYS.BOARD_INDEX, index);
-  }, [boards, activeBoardId]);
-
-  const setNextCardNumber = useCallback(
-    (n: number) => {
-      nextCardNumberRef.current = n;
-      const index: BoardIndex = {
-        boards,
-        activeBoardId,
-        nextCardNumber: n,
-      };
-      saveToStorage(STORAGE_KEYS.BOARD_INDEX, index);
-    },
-    [boards, activeBoardId],
+  const [nextCardNumber, setNextCardNumber] = useState(
+    indexRef.current.nextCardNumber,
   );
+
+  // Persist index whenever any part of it changes
+  useEffect(() => {
+    const index: BoardIndex = { boards, activeBoardId, nextCardNumber };
+    saveToStorage(STORAGE_KEYS.BOARD_INDEX, index);
+  }, [boards, activeBoardId, nextCardNumber]);
 
   const createBoard = useCallback((title: string): string => {
     const id = crypto.randomUUID();
@@ -125,22 +110,22 @@ export function BoardsProvider({
     return id;
   }, []);
 
+  const boardsRef = useRef(boards);
+  boardsRef.current = boards;
+
   const deleteBoard = useCallback(
     (id: string) => {
-      setBoards((prev) => {
-        if (prev.length <= 1) return prev;
-        const next = prev.filter((b) => b.id !== id);
-        if (next.length === prev.length) return prev;
+      const current = boardsRef.current;
+      if (current.length <= 1) return;
+      const next = current.filter((b) => b.id !== id);
+      if (next.length === current.length) return;
 
-        // Clean up board data from localStorage
-        window.localStorage.removeItem(boardStorageKey(id));
+      setBoards(next);
+      window.localStorage.removeItem(boardStorageKey(id));
 
-        // If deleting the active board, switch to the first remaining
-        if (id === activeBoardId) {
-          setActiveBoardId(next[0].id);
-        }
-        return next;
-      });
+      if (id === activeBoardId) {
+        setActiveBoardId(next[0].id);
+      }
     },
     [activeBoardId],
   );
@@ -187,7 +172,7 @@ export function BoardsProvider({
     () => ({
       boards,
       activeBoardId,
-      nextCardNumber: nextCardNumberRef.current,
+      nextCardNumber,
       createBoard,
       deleteBoard,
       renameBoard,
@@ -198,6 +183,7 @@ export function BoardsProvider({
     [
       boards,
       activeBoardId,
+      nextCardNumber,
       createBoard,
       deleteBoard,
       renameBoard,

--- a/src/boards/__tests__/BoardsProvider.test.ts
+++ b/src/boards/__tests__/BoardsProvider.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { BoardsProvider } from "../BoardsProvider";
+import { useBoards } from "../useBoards";
+import { STORAGE_KEYS, boardStorageKey } from "../../constants/storage";
+
+function wrapper({ children }: { children: ReactNode }) {
+  return createElement(BoardsProvider, null, children);
+}
+
+describe("BoardsProvider", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe("initialization", () => {
+    it("creates a default board for new users", () => {
+      const { result } = renderHook(() => useBoards(), { wrapper });
+
+      expect(result.current.boards).toHaveLength(1);
+      expect(result.current.boards[0].id).toBe("default");
+      expect(result.current.boards[0].title).toBe("My Board");
+      expect(result.current.activeBoardId).toBe("default");
+    });
+
+    it("persists the board index to localStorage", () => {
+      renderHook(() => useBoards(), { wrapper });
+
+      const stored = JSON.parse(
+        localStorage.getItem(STORAGE_KEYS.BOARD_INDEX) ?? "{}",
+      );
+      expect(stored.boards).toHaveLength(1);
+      expect(stored.activeBoardId).toBe("default");
+    });
+
+    it("loads existing board index from localStorage", () => {
+      const index = {
+        boards: [
+          {
+            id: "board-1",
+            title: "Work",
+            createdAt: "2025-01-01",
+            updatedAt: "2025-01-01",
+          },
+          {
+            id: "board-2",
+            title: "Personal",
+            createdAt: "2025-01-02",
+            updatedAt: "2025-01-02",
+          },
+        ],
+        activeBoardId: "board-2",
+        nextCardNumber: 10,
+      };
+      localStorage.setItem(STORAGE_KEYS.BOARD_INDEX, JSON.stringify(index));
+
+      const { result } = renderHook(() => useBoards(), { wrapper });
+
+      expect(result.current.boards).toHaveLength(2);
+      expect(result.current.activeBoardId).toBe("board-2");
+    });
+  });
+
+  describe("migration from single-board", () => {
+    it("migrates existing kanbeasy:board data to kanbeasy:board:default", () => {
+      const boardData = JSON.stringify({
+        columns: [{ id: "col-1", title: "Todo", cards: [] }],
+      });
+      localStorage.setItem(STORAGE_KEYS.BOARD, boardData);
+      localStorage.setItem(STORAGE_KEYS.NEXT_CARD_NUMBER, "7");
+
+      renderHook(() => useBoards(), { wrapper });
+
+      // Old key should be removed
+      expect(localStorage.getItem(STORAGE_KEYS.BOARD)).toBeNull();
+      expect(localStorage.getItem(STORAGE_KEYS.NEXT_CARD_NUMBER)).toBeNull();
+
+      // Data should be at the new key
+      expect(localStorage.getItem(boardStorageKey("default"))).toBe(boardData);
+
+      // Board index should be created
+      const index = JSON.parse(
+        localStorage.getItem(STORAGE_KEYS.BOARD_INDEX) ?? "{}",
+      );
+      expect(index.boards).toHaveLength(1);
+      expect(index.boards[0].id).toBe("default");
+      expect(index.boards[0].title).toBe("My Board");
+      expect(index.nextCardNumber).toBe(7);
+    });
+
+    it("migrates with zero card counter when none exists", () => {
+      localStorage.setItem(STORAGE_KEYS.BOARD, JSON.stringify({ columns: [] }));
+
+      renderHook(() => useBoards(), { wrapper });
+
+      const index = JSON.parse(
+        localStorage.getItem(STORAGE_KEYS.BOARD_INDEX) ?? "{}",
+      );
+      expect(index.nextCardNumber).toBe(0);
+    });
+  });
+
+  describe("createBoard", () => {
+    it("creates a new board and switches to it", () => {
+      const { result } = renderHook(() => useBoards(), { wrapper });
+
+      let newId: string;
+      act(() => {
+        newId = result.current.createBoard("Work Board");
+      });
+
+      expect(result.current.boards).toHaveLength(2);
+      expect(result.current.boards[1].title).toBe("Work Board");
+      expect(result.current.activeBoardId).toBe(newId!);
+    });
+
+    it("assigns timestamps to new boards", () => {
+      const { result } = renderHook(() => useBoards(), { wrapper });
+
+      act(() => {
+        result.current.createBoard("New Board");
+      });
+
+      const newBoard = result.current.boards[1];
+      expect(newBoard.createdAt).toBeTruthy();
+      expect(newBoard.updatedAt).toBeTruthy();
+    });
+  });
+
+  describe("deleteBoard", () => {
+    it("deletes a board and removes its localStorage data", () => {
+      const { result } = renderHook(() => useBoards(), { wrapper });
+
+      let boardId: string;
+      act(() => {
+        boardId = result.current.createBoard("To Delete");
+      });
+
+      // Set some data for that board
+      localStorage.setItem(
+        boardStorageKey(boardId!),
+        JSON.stringify({ columns: [] }),
+      );
+
+      act(() => {
+        result.current.deleteBoard(boardId!);
+      });
+
+      expect(result.current.boards).toHaveLength(1);
+      expect(localStorage.getItem(boardStorageKey(boardId!))).toBeNull();
+    });
+
+    it("cannot delete the last remaining board", () => {
+      const { result } = renderHook(() => useBoards(), { wrapper });
+
+      expect(result.current.boards).toHaveLength(1);
+
+      act(() => {
+        result.current.deleteBoard(result.current.boards[0].id);
+      });
+
+      expect(result.current.boards).toHaveLength(1);
+    });
+
+    it("switches to first remaining board when deleting the active board", () => {
+      const { result } = renderHook(() => useBoards(), { wrapper });
+
+      act(() => {
+        result.current.createBoard("Second");
+      });
+      act(() => {
+        result.current.createBoard("Third");
+      });
+
+      // Active is now "Third" (the last created)
+      const thirdId = result.current.activeBoardId;
+
+      act(() => {
+        result.current.deleteBoard(thirdId);
+      });
+
+      // Should switch to first board
+      expect(result.current.activeBoardId).toBe(result.current.boards[0].id);
+    });
+
+    it("does not switch when deleting a non-active board", () => {
+      const { result } = renderHook(() => useBoards(), { wrapper });
+
+      let secondId: string;
+      act(() => {
+        secondId = result.current.createBoard("Second");
+      });
+
+      // Switch back to first
+      act(() => {
+        result.current.switchBoard(result.current.boards[0].id);
+      });
+
+      const activeBeforeDelete = result.current.activeBoardId;
+
+      act(() => {
+        result.current.deleteBoard(secondId!);
+      });
+
+      expect(result.current.activeBoardId).toBe(activeBeforeDelete);
+    });
+  });
+
+  describe("renameBoard", () => {
+    it("renames a board and updates its title", () => {
+      const { result } = renderHook(() => useBoards(), { wrapper });
+
+      act(() => {
+        result.current.renameBoard("default", "Renamed Board");
+      });
+
+      expect(result.current.boards[0].title).toBe("Renamed Board");
+      expect(result.current.boards[0].updatedAt).toBeTruthy();
+    });
+  });
+
+  describe("switchBoard", () => {
+    it("changes the active board ID", () => {
+      const { result } = renderHook(() => useBoards(), { wrapper });
+
+      let secondId: string;
+      act(() => {
+        secondId = result.current.createBoard("Second");
+      });
+      act(() => {
+        result.current.switchBoard("default");
+      });
+
+      expect(result.current.activeBoardId).toBe("default");
+
+      act(() => {
+        result.current.switchBoard(secondId!);
+      });
+
+      expect(result.current.activeBoardId).toBe(secondId!);
+    });
+  });
+
+  describe("duplicateBoard", () => {
+    it("copies board data and inserts after the source", () => {
+      const { result } = renderHook(() => useBoards(), { wrapper });
+
+      // Store data for the default board
+      const boardData = JSON.stringify({
+        columns: [{ id: "c1", title: "Col", cards: [] }],
+      });
+      localStorage.setItem(boardStorageKey("default"), boardData);
+
+      let dupId: string;
+      act(() => {
+        dupId = result.current.duplicateBoard("default", "Copy of My Board");
+      });
+
+      expect(result.current.boards).toHaveLength(2);
+      expect(result.current.boards[1].title).toBe("Copy of My Board");
+      expect(result.current.activeBoardId).toBe(dupId!);
+
+      // Board data should be copied
+      expect(localStorage.getItem(boardStorageKey(dupId!))).toBe(boardData);
+    });
+
+    it("inserts duplicate after the source board", () => {
+      const { result } = renderHook(() => useBoards(), { wrapper });
+
+      act(() => {
+        result.current.createBoard("Second");
+      });
+      act(() => {
+        result.current.createBoard("Third");
+      });
+
+      // Duplicate the first board
+      act(() => {
+        result.current.duplicateBoard("default", "Default Copy");
+      });
+
+      // "Default Copy" should be at index 1 (right after "default")
+      expect(result.current.boards[0].id).toBe("default");
+      expect(result.current.boards[1].title).toBe("Default Copy");
+    });
+  });
+
+  describe("setNextCardNumber", () => {
+    it("persists the card counter to the board index", () => {
+      const { result } = renderHook(() => useBoards(), { wrapper });
+
+      act(() => {
+        result.current.setNextCardNumber(42);
+      });
+
+      const index = JSON.parse(
+        localStorage.getItem(STORAGE_KEYS.BOARD_INDEX) ?? "{}",
+      );
+      expect(index.nextCardNumber).toBe(42);
+    });
+  });
+
+  describe("useBoards hook", () => {
+    it("throws when used outside BoardsProvider", () => {
+      expect(() => renderHook(() => useBoards())).toThrow(
+        "useBoards must be used within a BoardsProvider",
+      );
+    });
+  });
+});

--- a/src/boards/__tests__/BoardsProvider.test.ts
+++ b/src/boards/__tests__/BoardsProvider.test.ts
@@ -299,6 +299,18 @@ describe("BoardsProvider", () => {
       );
       expect(index.nextCardNumber).toBe(42);
     });
+
+    it("updates the context value reactively", () => {
+      const { result } = renderHook(() => useBoards(), { wrapper });
+
+      expect(result.current.nextCardNumber).toBe(0);
+
+      act(() => {
+        result.current.setNextCardNumber(10);
+      });
+
+      expect(result.current.nextCardNumber).toBe(10);
+    });
   });
 
   describe("useBoards hook", () => {

--- a/src/boards/__tests__/boardStorageKey.test.ts
+++ b/src/boards/__tests__/boardStorageKey.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from "vitest";
+import { boardStorageKey } from "../../constants/storage";
+
+describe("boardStorageKey", () => {
+  it("returns a namespaced key for a given board ID", () => {
+    expect(boardStorageKey("default")).toBe("kanbeasy:board:default");
+  });
+
+  it("handles UUID board IDs", () => {
+    const uuid = "550e8400-e29b-41d4-a716-446655440000";
+    expect(boardStorageKey(uuid)).toBe(`kanbeasy:board:${uuid}`);
+  });
+});

--- a/src/boards/__tests__/boardSwitching.integration.test.ts
+++ b/src/boards/__tests__/boardSwitching.integration.test.ts
@@ -161,6 +161,26 @@ describe("board switching integration", () => {
     expect(result.current.board.canRedo).toBe(false);
   });
 
+  it("new boards created via createBoard have empty columns", () => {
+    const { result } = renderHook(
+      () => ({ boards: useBoards(), board: useBoard() }),
+      { wrapper },
+    );
+
+    // Create a second board
+    act(() => {
+      result.current.boards.createBoard("Second Board");
+    });
+
+    // New board should have 3 columns with zero cards
+    expect(result.current.board.columns).toHaveLength(3);
+    const totalCards = result.current.board.columns.reduce(
+      (sum, col) => sum + col.cards.length,
+      0,
+    );
+    expect(totalCards).toBe(0);
+  });
+
   it("persists board data to the correct storage key", () => {
     const { result } = renderHook(
       () => ({ boards: useBoards(), board: useBoard() }),

--- a/src/boards/__tests__/boardSwitching.integration.test.ts
+++ b/src/boards/__tests__/boardSwitching.integration.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { BoardsProvider } from "../BoardsProvider";
+import { BoardProvider } from "../../board/BoardProvider";
+import { useBoards } from "../useBoards";
+import { useBoard } from "../../board/useBoard";
+import { boardStorageKey } from "../../constants/storage";
+
+function wrapper({ children }: { children: ReactNode }) {
+  return createElement(
+    BoardsProvider,
+    null,
+    createElement(BoardProvider, null, children),
+  );
+}
+
+describe("board switching integration", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("new board starts with default columns", () => {
+    const { result } = renderHook(
+      () => ({ boards: useBoards(), board: useBoard() }),
+      { wrapper },
+    );
+
+    // Default board has 3 columns
+    expect(result.current.board.columns).toHaveLength(3);
+  });
+
+  it("switching boards loads the correct data", () => {
+    // Seed two boards with different data
+    const board1Data = {
+      columns: [
+        {
+          id: "col-a",
+          title: "Board 1 Column",
+          cards: [],
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      ],
+      archive: [],
+    };
+    const board2Data = {
+      columns: [
+        {
+          id: "col-b",
+          title: "Board 2 Column",
+          cards: [],
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+        {
+          id: "col-c",
+          title: "Board 2 Column 2",
+          cards: [],
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      ],
+      archive: [],
+    };
+
+    localStorage.setItem(
+      boardStorageKey("board-a"),
+      JSON.stringify(board1Data),
+    );
+    localStorage.setItem(
+      boardStorageKey("board-b"),
+      JSON.stringify(board2Data),
+    );
+
+    const index = {
+      boards: [
+        {
+          id: "board-a",
+          title: "First",
+          createdAt: "2025-01-01",
+          updatedAt: "2025-01-01",
+        },
+        {
+          id: "board-b",
+          title: "Second",
+          createdAt: "2025-01-02",
+          updatedAt: "2025-01-02",
+        },
+      ],
+      activeBoardId: "board-a",
+      nextCardNumber: 1,
+    };
+    localStorage.setItem("kanbeasy:boardIndex", JSON.stringify(index));
+
+    const { result } = renderHook(
+      () => ({ boards: useBoards(), board: useBoard() }),
+      { wrapper },
+    );
+
+    // Should load board-a data
+    expect(result.current.board.columns).toHaveLength(1);
+    expect(result.current.board.columns[0].title).toBe("Board 1 Column");
+
+    // Switch to board-b
+    act(() => {
+      result.current.boards.switchBoard("board-b");
+    });
+
+    expect(result.current.board.columns).toHaveLength(2);
+    expect(result.current.board.columns[0].title).toBe("Board 2 Column");
+  });
+
+  it("mutations on one board do not affect another", () => {
+    const { result } = renderHook(
+      () => ({ boards: useBoards(), board: useBoard() }),
+      { wrapper },
+    );
+
+    // Add a column to the default board
+    act(() => {
+      result.current.board.addColumn("Extra Column");
+    });
+    const defaultColumnCount = result.current.board.columns.length;
+
+    // Create a new board (which auto-switches)
+    act(() => {
+      result.current.boards.createBoard("Second Board");
+    });
+
+    // New board should have default 3 columns, not affected by default board
+    expect(result.current.board.columns).toHaveLength(3);
+
+    // Switch back to default board
+    act(() => {
+      result.current.boards.switchBoard("default");
+    });
+
+    expect(result.current.board.columns).toHaveLength(defaultColumnCount);
+  });
+
+  it("undo/redo history resets when switching boards", () => {
+    const { result } = renderHook(
+      () => ({ boards: useBoards(), board: useBoard() }),
+      { wrapper },
+    );
+
+    // Make a change so we have undo history
+    act(() => {
+      result.current.board.addColumn("New Column");
+    });
+    expect(result.current.board.canUndo).toBe(true);
+
+    // Create and switch to a new board
+    act(() => {
+      result.current.boards.createBoard("Second");
+    });
+
+    // Undo history should be cleared
+    expect(result.current.board.canUndo).toBe(false);
+    expect(result.current.board.canRedo).toBe(false);
+  });
+
+  it("persists board data to the correct storage key", () => {
+    const { result } = renderHook(
+      () => ({ boards: useBoards(), board: useBoard() }),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.board.addColumn("Test Column");
+    });
+
+    const stored = JSON.parse(
+      localStorage.getItem(boardStorageKey("default")) ?? "{}",
+    );
+    expect(
+      stored.columns.some((c: { title: string }) => c.title === "Test Column"),
+    ).toBe(true);
+  });
+});

--- a/src/boards/types.ts
+++ b/src/boards/types.ts
@@ -1,0 +1,24 @@
+export type BoardMeta = Readonly<{
+  id: string;
+  title: string;
+  createdAt: string;
+  updatedAt: string;
+}>;
+
+export type BoardIndex = Readonly<{
+  boards: BoardMeta[];
+  activeBoardId: string;
+  nextCardNumber: number;
+}>;
+
+export type BoardsContextValue = Readonly<{
+  boards: BoardMeta[];
+  activeBoardId: string;
+  nextCardNumber: number;
+  createBoard: (title: string) => string;
+  deleteBoard: (id: string) => void;
+  renameBoard: (id: string, title: string) => void;
+  switchBoard: (id: string) => void;
+  duplicateBoard: (id: string, title: string) => string;
+  setNextCardNumber: (n: number) => void;
+}>;

--- a/src/boards/useBoards.ts
+++ b/src/boards/useBoards.ts
@@ -1,0 +1,10 @@
+import { useContext } from "react";
+import { BoardsContext } from "./BoardsContext";
+
+export function useBoards() {
+  const ctx = useContext(BoardsContext);
+  if (!ctx) {
+    throw new Error("useBoards must be used within a BoardsProvider");
+  }
+  return ctx;
+}

--- a/src/components/BoardTabs.tsx
+++ b/src/components/BoardTabs.tsx
@@ -1,0 +1,233 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useBoards } from "../boards/useBoards";
+import { useBoardSwitchKeyboard } from "../hooks";
+import { tc } from "../theme/classNames";
+import { PlusIcon } from "./icons";
+
+export function BoardTabs() {
+  const {
+    boards,
+    activeBoardId,
+    switchBoard,
+    createBoard,
+    deleteBoard,
+    renameBoard,
+    duplicateBoard,
+  } = useBoards();
+
+  useBoardSwitchKeyboard({ boards, activeBoardId, switchBoard });
+
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState("");
+  const [creatingNew, setCreatingNew] = useState(false);
+  const [newBoardTitle, setNewBoardTitle] = useState("");
+  const [contextMenu, setContextMenu] = useState<{
+    boardId: string;
+    x: number;
+    y: number;
+  } | null>(null);
+
+  const editInputRef = useRef<HTMLInputElement>(null);
+  const newInputRef = useRef<HTMLInputElement>(null);
+  const contextMenuRef = useRef<HTMLDivElement>(null);
+
+  // Focus input when editing starts
+  useEffect(() => {
+    if (editingId && editInputRef.current) {
+      editInputRef.current.focus();
+      editInputRef.current.select();
+    }
+  }, [editingId]);
+
+  useEffect(() => {
+    if (creatingNew && newInputRef.current) {
+      newInputRef.current.focus();
+    }
+  }, [creatingNew]);
+
+  // Close context menu on outside click
+  useEffect(() => {
+    if (!contextMenu) return;
+    const handler = (e: MouseEvent) => {
+      if (
+        contextMenuRef.current &&
+        !contextMenuRef.current.contains(e.target as Node)
+      ) {
+        setContextMenu(null);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [contextMenu]);
+
+  const handleContextMenu = useCallback(
+    (e: React.MouseEvent, boardId: string) => {
+      e.preventDefault();
+      setContextMenu({ boardId, x: e.clientX, y: e.clientY });
+    },
+    [],
+  );
+
+  const startRename = useCallback(
+    (id: string) => {
+      const board = boards.find((b) => b.id === id);
+      if (!board) return;
+      setEditingId(id);
+      setEditValue(board.title);
+      setContextMenu(null);
+    },
+    [boards],
+  );
+
+  const commitRename = useCallback(() => {
+    if (editingId && editValue.trim()) {
+      renameBoard(editingId, editValue.trim());
+    }
+    setEditingId(null);
+    setEditValue("");
+  }, [editingId, editValue, renameBoard]);
+
+  const handleDelete = useCallback(
+    (id: string) => {
+      setContextMenu(null);
+      if (boards.length <= 1) return;
+      const board = boards.find((b) => b.id === id);
+      const confirmed = window.confirm(
+        `Delete "${board?.title}"? This will permanently remove all columns, cards, and archived cards in this board.`,
+      );
+      if (confirmed) {
+        deleteBoard(id);
+      }
+    },
+    [boards, deleteBoard],
+  );
+
+  const handleDuplicate = useCallback(
+    (id: string) => {
+      setContextMenu(null);
+      const board = boards.find((b) => b.id === id);
+      if (board) {
+        duplicateBoard(id, `${board.title} (copy)`);
+      }
+    },
+    [boards, duplicateBoard],
+  );
+
+  const commitNewBoard = useCallback(() => {
+    const title = newBoardTitle.trim();
+    if (title) {
+      createBoard(title);
+    }
+    setCreatingNew(false);
+    setNewBoardTitle("");
+  }, [newBoardTitle, createBoard]);
+
+  return (
+    <div
+      className={`border-b ${tc.borderSubtle} bg-surface/80 backdrop-blur supports-[backdrop-filter]:bg-surface/60`}
+    >
+      <div className="mx-auto max-w-6xl px-4 flex items-center gap-1 overflow-x-auto scrollbar-thin">
+        {boards.map((board) => (
+          <button
+            key={board.id}
+            type="button"
+            className={`relative shrink-0 px-3 py-2 text-sm font-medium transition-colors ${tc.focusRing} rounded-t-md ${
+              board.id === activeBoardId
+                ? `${tc.text} after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:bg-accent`
+                : `${tc.textMuted} ${tc.bgHover}`
+            }`}
+            onClick={() => switchBoard(board.id)}
+            onContextMenu={(e) => handleContextMenu(e, board.id)}
+            onDoubleClick={() => startRename(board.id)}
+            aria-current={board.id === activeBoardId ? "page" : undefined}
+            data-testid={`board-tab-${board.id}`}
+          >
+            {editingId === board.id ? (
+              <input
+                ref={editInputRef}
+                type="text"
+                className={`bg-transparent border-0 outline-hidden text-sm font-medium w-24 ${tc.text}`}
+                value={editValue}
+                onChange={(e) => setEditValue(e.target.value)}
+                onBlur={commitRename}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") commitRename();
+                  if (e.key === "Escape") {
+                    setEditingId(null);
+                    setEditValue("");
+                  }
+                }}
+              />
+            ) : (
+              board.title
+            )}
+          </button>
+        ))}
+
+        {creatingNew ? (
+          <div className="shrink-0 px-1 py-2">
+            <input
+              ref={newInputRef}
+              type="text"
+              className={`bg-transparent border ${tc.border} rounded px-2 py-0.5 text-sm w-32 ${tc.text} ${tc.focusRing}`}
+              placeholder="Board name..."
+              value={newBoardTitle}
+              onChange={(e) => setNewBoardTitle(e.target.value)}
+              onBlur={commitNewBoard}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") commitNewBoard();
+                if (e.key === "Escape") {
+                  setCreatingNew(false);
+                  setNewBoardTitle("");
+                }
+              }}
+            />
+          </div>
+        ) : (
+          <button
+            type="button"
+            className={`shrink-0 p-2 rounded-md ${tc.iconButton} ${tc.textMuted}`}
+            aria-label="Create new board"
+            onClick={() => setCreatingNew(true)}
+            data-testid="create-board-button"
+          >
+            <PlusIcon className="size-4" />
+          </button>
+        )}
+      </div>
+
+      {/* Context Menu */}
+      {contextMenu && (
+        <div
+          ref={contextMenuRef}
+          className={`fixed z-50 min-w-40 py-1 rounded-lg border ${tc.border} ${tc.glassOpaque} backdrop-blur-md shadow-lg`}
+          style={{ left: contextMenu.x, top: contextMenu.y }}
+        >
+          <button
+            type="button"
+            className={`w-full text-left px-3 py-1.5 text-sm ${tc.text} ${tc.bgHover}`}
+            onClick={() => startRename(contextMenu.boardId)}
+          >
+            Rename
+          </button>
+          <button
+            type="button"
+            className={`w-full text-left px-3 py-1.5 text-sm ${tc.text} ${tc.bgHover}`}
+            onClick={() => handleDuplicate(contextMenu.boardId)}
+          >
+            Duplicate
+          </button>
+          {boards.length > 1 && (
+            <button
+              type="button"
+              className={`w-full text-left px-3 py-1.5 text-sm text-red-600 dark:text-red-400 ${tc.bgHover}`}
+              onClick={() => handleDelete(contextMenu.boardId)}
+            >
+              Delete
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/BoardTabs.tsx
+++ b/src/components/BoardTabs.tsx
@@ -45,10 +45,10 @@ export function BoardTabs() {
     }
   }, [creatingNew]);
 
-  // Close context menu on outside click
+  // Close context menu on outside click or Escape
   useEffect(() => {
     if (!contextMenu) return;
-    const handler = (e: MouseEvent) => {
+    const handleMouseDown = (e: MouseEvent) => {
       if (
         contextMenuRef.current &&
         !contextMenuRef.current.contains(e.target as Node)
@@ -56,8 +56,15 @@ export function BoardTabs() {
         setContextMenu(null);
       }
     };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setContextMenu(null);
+    };
+    document.addEventListener("mousedown", handleMouseDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handleMouseDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
   }, [contextMenu]);
 
   const handleContextMenu = useCallback(

--- a/src/components/__tests__/BoardTabs.test.tsx
+++ b/src/components/__tests__/BoardTabs.test.tsx
@@ -294,5 +294,20 @@ describe("BoardTabs", () => {
         screen.queryByRole("button", { name: "Rename" }),
       ).not.toBeInTheDocument();
     });
+
+    it("closes context menu on Escape", async () => {
+      renderTabs();
+
+      fireEvent.contextMenu(screen.getByTestId("board-tab-board-1"));
+      expect(
+        screen.getByRole("button", { name: "Rename" }),
+      ).toBeInTheDocument();
+
+      await userEvent.keyboard("{Escape}");
+
+      expect(
+        screen.queryByRole("button", { name: "Rename" }),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/__tests__/BoardTabs.test.tsx
+++ b/src/components/__tests__/BoardTabs.test.tsx
@@ -1,0 +1,298 @@
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { BoardTabs } from "../BoardTabs";
+import { BoardsContext } from "../../boards/BoardsContext";
+import type { BoardsContextValue } from "../../boards/types";
+
+const noop = () => {};
+
+function makeBoardsValue(
+  overrides: Partial<BoardsContextValue> = {},
+): BoardsContextValue {
+  return {
+    boards: [
+      {
+        id: "board-1",
+        title: "Personal",
+        createdAt: "2025-01-01",
+        updatedAt: "2025-01-01",
+      },
+      {
+        id: "board-2",
+        title: "Work",
+        createdAt: "2025-01-02",
+        updatedAt: "2025-01-02",
+      },
+    ],
+    activeBoardId: "board-1",
+    nextCardNumber: 1,
+    createBoard: () => "new-id",
+    deleteBoard: noop,
+    renameBoard: noop,
+    switchBoard: noop,
+    duplicateBoard: () => "dup-id",
+    setNextCardNumber: noop,
+    ...overrides,
+  };
+}
+
+function renderTabs(overrides: Partial<BoardsContextValue> = {}) {
+  const value = makeBoardsValue(overrides);
+  return render(
+    <BoardsContext.Provider value={value}>
+      <BoardTabs />
+    </BoardsContext.Provider>,
+  );
+}
+
+describe("BoardTabs", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe("rendering", () => {
+    it("renders a tab for each board", () => {
+      renderTabs();
+
+      expect(screen.getByText("Personal")).toBeInTheDocument();
+      expect(screen.getByText("Work")).toBeInTheDocument();
+    });
+
+    it("marks the active board tab with aria-current", () => {
+      renderTabs();
+
+      const personalTab = screen.getByTestId("board-tab-board-1");
+      const workTab = screen.getByTestId("board-tab-board-2");
+
+      expect(personalTab).toHaveAttribute("aria-current", "page");
+      expect(workTab).not.toHaveAttribute("aria-current");
+    });
+
+    it("shows the create new board button", () => {
+      renderTabs();
+
+      expect(
+        screen.getByRole("button", { name: "Create new board" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("switching boards", () => {
+    it("calls switchBoard when clicking a tab", async () => {
+      const switchBoard = vi.fn();
+      renderTabs({ switchBoard });
+
+      await userEvent.click(screen.getByText("Work"));
+
+      expect(switchBoard).toHaveBeenCalledWith("board-2");
+    });
+  });
+
+  describe("creating boards", () => {
+    it("shows an input when clicking the create button", async () => {
+      renderTabs();
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Create new board" }),
+      );
+
+      expect(screen.getByPlaceholderText("Board name...")).toBeInTheDocument();
+    });
+
+    it("calls createBoard on Enter", async () => {
+      const createBoard = vi.fn().mockReturnValue("new-id");
+      renderTabs({ createBoard });
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Create new board" }),
+      );
+      const input = screen.getByPlaceholderText("Board name...");
+      await userEvent.type(input, "New Board{enter}");
+
+      expect(createBoard).toHaveBeenCalledWith("New Board");
+    });
+
+    it("does not create board with empty title", async () => {
+      const createBoard = vi.fn().mockReturnValue("new-id");
+      renderTabs({ createBoard });
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Create new board" }),
+      );
+      const input = screen.getByPlaceholderText("Board name...");
+      await userEvent.type(input, "{enter}");
+
+      expect(createBoard).not.toHaveBeenCalled();
+    });
+
+    it("cancels creation on Escape", async () => {
+      renderTabs();
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Create new board" }),
+      );
+      expect(screen.getByPlaceholderText("Board name...")).toBeInTheDocument();
+
+      await userEvent.keyboard("{Escape}");
+
+      expect(
+        screen.queryByPlaceholderText("Board name..."),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Create new board" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("renaming boards", () => {
+    it("shows an inline input on double-click", async () => {
+      renderTabs();
+
+      fireEvent.doubleClick(screen.getByTestId("board-tab-board-1"));
+
+      const input = screen.getByDisplayValue("Personal");
+      expect(input).toBeInTheDocument();
+    });
+
+    it("calls renameBoard on blur", async () => {
+      const renameBoard = vi.fn();
+      renderTabs({ renameBoard });
+
+      fireEvent.doubleClick(screen.getByTestId("board-tab-board-1"));
+
+      const input = screen.getByDisplayValue("Personal");
+      await userEvent.clear(input);
+      await userEvent.type(input, "Updated");
+      fireEvent.blur(input);
+
+      expect(renameBoard).toHaveBeenCalledWith("board-1", "Updated");
+    });
+
+    it("calls renameBoard on Enter", async () => {
+      const renameBoard = vi.fn();
+      renderTabs({ renameBoard });
+
+      fireEvent.doubleClick(screen.getByTestId("board-tab-board-1"));
+
+      const input = screen.getByDisplayValue("Personal");
+      await userEvent.clear(input);
+      await userEvent.type(input, "New Name{enter}");
+
+      expect(renameBoard).toHaveBeenCalledWith("board-1", "New Name");
+    });
+
+    it("cancels rename on Escape", async () => {
+      const renameBoard = vi.fn();
+      renderTabs({ renameBoard });
+
+      fireEvent.doubleClick(screen.getByTestId("board-tab-board-1"));
+
+      await userEvent.keyboard("{Escape}");
+
+      expect(renameBoard).not.toHaveBeenCalled();
+      expect(screen.getByText("Personal")).toBeInTheDocument();
+    });
+  });
+
+  describe("context menu", () => {
+    it("shows context menu on right-click", () => {
+      renderTabs();
+
+      fireEvent.contextMenu(screen.getByTestId("board-tab-board-1"));
+
+      expect(
+        screen.getByRole("button", { name: "Rename" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Duplicate" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Delete" }),
+      ).toBeInTheDocument();
+    });
+
+    it("calls duplicateBoard from context menu", async () => {
+      const duplicateBoard = vi.fn().mockReturnValue("dup-id");
+      renderTabs({ duplicateBoard });
+
+      fireEvent.contextMenu(screen.getByTestId("board-tab-board-1"));
+      await userEvent.click(screen.getByRole("button", { name: "Duplicate" }));
+
+      expect(duplicateBoard).toHaveBeenCalledWith("board-1", "Personal (copy)");
+    });
+
+    it("confirms before deleting from context menu", async () => {
+      const deleteBoard = vi.fn();
+      const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+      renderTabs({ deleteBoard });
+
+      fireEvent.contextMenu(screen.getByTestId("board-tab-board-2"));
+      await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+      expect(confirmSpy).toHaveBeenCalled();
+      expect(deleteBoard).toHaveBeenCalledWith("board-2");
+      confirmSpy.mockRestore();
+    });
+
+    it("does not delete when confirm is cancelled", async () => {
+      const deleteBoard = vi.fn();
+      const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+      renderTabs({ deleteBoard });
+
+      fireEvent.contextMenu(screen.getByTestId("board-tab-board-2"));
+      await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+      expect(deleteBoard).not.toHaveBeenCalled();
+      confirmSpy.mockRestore();
+    });
+
+    it("hides delete option when only one board exists", () => {
+      renderTabs({
+        boards: [
+          {
+            id: "only",
+            title: "Only Board",
+            createdAt: "2025-01-01",
+            updatedAt: "2025-01-01",
+          },
+        ],
+        activeBoardId: "only",
+      });
+
+      fireEvent.contextMenu(screen.getByTestId("board-tab-only"));
+
+      expect(
+        screen.getByRole("button", { name: "Rename" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Delete" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("starts rename from context menu", async () => {
+      renderTabs();
+
+      fireEvent.contextMenu(screen.getByTestId("board-tab-board-1"));
+      await userEvent.click(screen.getByRole("button", { name: "Rename" }));
+
+      expect(screen.getByDisplayValue("Personal")).toBeInTheDocument();
+    });
+
+    it("closes context menu on outside click", () => {
+      renderTabs();
+
+      fireEvent.contextMenu(screen.getByTestId("board-tab-board-1"));
+      expect(
+        screen.getByRole("button", { name: "Rename" }),
+      ).toBeInTheDocument();
+
+      fireEvent.mouseDown(document.body);
+
+      expect(
+        screen.queryByRole("button", { name: "Rename" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/icons/PlusIcon.tsx
+++ b/src/components/icons/PlusIcon.tsx
@@ -1,0 +1,14 @@
+import type { FC, SVGProps } from "react";
+
+export const PlusIcon: FC<SVGProps<SVGSVGElement>> = (props) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 -960 960 960"
+    fill="currentColor"
+    aria-hidden
+    focusable="false"
+    {...props}
+  >
+    <path d="M440-440H200v-80h240v-240h80v240h240v80H520v240h-80v-240Z" />
+  </svg>
+);

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -12,6 +12,7 @@ export { DragIndicatorIcon } from "./DragIndicatorIcon";
 export { ListViewIcon } from "./ListViewIcon";
 export { MoreIcon } from "./MoreIcon";
 export { OwlIcon, SleepyOwlIcon } from "./OwlIcon";
+export { PlusIcon } from "./PlusIcon";
 export { RedoIcon } from "./RedoIcon";
 export { SettingsGearIcon } from "./SettingsGearIcon";
 export { UndoIcon } from "./UndoIcon";

--- a/src/components/settings/__tests__/CardTypeSection.test.tsx
+++ b/src/components/settings/__tests__/CardTypeSection.test.tsx
@@ -2,18 +2,21 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { CardTypeSection } from "../CardTypeSection";
 import { ThemeProvider } from "../../../theme/ThemeProvider";
+import { BoardsProvider } from "../../../boards/BoardsProvider";
 import { BoardProvider } from "../../../board/BoardProvider";
 import { CARD_TYPE_PRESETS } from "../../../constants/cardTypes";
-import { STORAGE_KEYS } from "../../../constants/storage";
+import { STORAGE_KEYS, boardStorageKey } from "../../../constants/storage";
 import { describe, beforeEach, it, expect, vi } from "vitest";
 
 function renderSection() {
   return render(
-    <BoardProvider>
-      <ThemeProvider>
-        <CardTypeSection />
-      </ThemeProvider>
-    </BoardProvider>,
+    <BoardsProvider>
+      <BoardProvider>
+        <ThemeProvider>
+          <CardTypeSection />
+        </ThemeProvider>
+      </BoardProvider>
+    </BoardsProvider>,
   );
 }
 
@@ -218,7 +221,7 @@ describe("CardTypeSection", () => {
       // While typing, the card should still have cardTypeId "feat" in localStorage
       // because renameCardType hasn't been called yet
       const boardDuringTyping = JSON.parse(
-        localStorage.getItem(STORAGE_KEYS.BOARD) ?? "{}",
+        localStorage.getItem(boardStorageKey("default")) ?? "{}",
       );
       expect(boardDuringTyping.columns[0].cards[0].cardTypeId).toBe("feat");
 
@@ -229,7 +232,7 @@ describe("CardTypeSection", () => {
       // Wait for state to settle
       await vi.waitFor(() => {
         const boardAfterBlur = JSON.parse(
-          localStorage.getItem(STORAGE_KEYS.BOARD) ?? "{}",
+          localStorage.getItem(boardStorageKey("default")) ?? "{}",
         );
         expect(boardAfterBlur.columns[0].cards[0].cardTypeId).toBe("story");
       });
@@ -324,7 +327,7 @@ describe("CardTypeSection", () => {
       // Card should still have cardTypeId "feat" — type definition
       // removal should not wipe card data
       const board = JSON.parse(
-        localStorage.getItem(STORAGE_KEYS.BOARD) ?? "{}",
+        localStorage.getItem(boardStorageKey("default")) ?? "{}",
       );
       expect(board.columns[0].cards[0].cardTypeId).toBe("feat");
     });

--- a/src/components/settings/__tests__/SettingsModal.test.tsx
+++ b/src/components/settings/__tests__/SettingsModal.test.tsx
@@ -2,6 +2,7 @@ import "@testing-library/jest-dom";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { SettingsModal } from "../SettingsModal";
 import { ThemeProvider } from "../../../theme/ThemeProvider";
+import { BoardsProvider } from "../../../boards/BoardsProvider";
 import { BoardProvider } from "../../../board/BoardProvider";
 import { vi, describe, it, expect } from "vitest";
 
@@ -12,11 +13,13 @@ function expandDataSection() {
 describe("SettingsModal", () => {
   it("renders three separate clear buttons", () => {
     render(
-      <BoardProvider>
-        <ThemeProvider>
-          <SettingsModal open={true} onClose={vi.fn()} />
-        </ThemeProvider>
-      </BoardProvider>,
+      <BoardsProvider>
+        <BoardProvider>
+          <ThemeProvider>
+            <SettingsModal open={true} onClose={vi.fn()} />
+          </ThemeProvider>
+        </BoardProvider>
+      </BoardsProvider>,
     );
     expandDataSection();
     expect(
@@ -34,11 +37,13 @@ describe("SettingsModal", () => {
     window.localStorage.setItem("kanbeasy:theme", "dark-slate");
     window.localStorage.setItem("kanbeasy:cardDensity", "large");
     render(
-      <BoardProvider>
-        <ThemeProvider>
-          <SettingsModal open={true} onClose={vi.fn()} />
-        </ThemeProvider>
-      </BoardProvider>,
+      <BoardsProvider>
+        <BoardProvider>
+          <ThemeProvider>
+            <SettingsModal open={true} onClose={vi.fn()} />
+          </ThemeProvider>
+        </BoardProvider>
+      </BoardsProvider>,
     );
     expandDataSection();
     fireEvent.click(screen.getByRole("button", { name: "Clear board data" }));
@@ -50,16 +55,20 @@ describe("SettingsModal", () => {
   it("clears settings but preserves board when 'Clear settings' is clicked", () => {
     window.localStorage.setItem("kanbeasy:cardDensity", "large");
     render(
-      <BoardProvider>
-        <ThemeProvider>
-          <SettingsModal open={true} onClose={vi.fn()} />
-        </ThemeProvider>
-      </BoardProvider>,
+      <BoardsProvider>
+        <BoardProvider>
+          <ThemeProvider>
+            <SettingsModal open={true} onClose={vi.fn()} />
+          </ThemeProvider>
+        </BoardProvider>
+      </BoardsProvider>,
     );
     expandDataSection();
     fireEvent.click(screen.getByRole("button", { name: "Clear settings" }));
-    // Board data should still exist
-    expect(window.localStorage.getItem("kanbeasy:board")).not.toBeNull();
+    // Board data should still exist (stored under board:default after migration)
+    expect(
+      window.localStorage.getItem("kanbeasy:board:default"),
+    ).not.toBeNull();
     // Card density should be reset to default "small" (compact)
     expect(window.localStorage.getItem("kanbeasy:cardDensity")).toBe("small");
   });
@@ -67,11 +76,13 @@ describe("SettingsModal", () => {
   it("clears all data when 'Clear all data' is clicked", () => {
     window.localStorage.setItem("kanbeasy:cardDensity", "large");
     render(
-      <BoardProvider>
-        <ThemeProvider>
-          <SettingsModal open={true} onClose={vi.fn()} />
-        </ThemeProvider>
-      </BoardProvider>,
+      <BoardsProvider>
+        <BoardProvider>
+          <ThemeProvider>
+            <SettingsModal open={true} onClose={vi.fn()} />
+          </ThemeProvider>
+        </BoardProvider>
+      </BoardsProvider>,
     );
     expandDataSection();
     fireEvent.click(screen.getByRole("button", { name: "Clear all data" }));
@@ -81,11 +92,13 @@ describe("SettingsModal", () => {
 
   it("renders the modal when open", () => {
     render(
-      <BoardProvider>
-        <ThemeProvider>
-          <SettingsModal open={true} onClose={vi.fn()} />
-        </ThemeProvider>
-      </BoardProvider>,
+      <BoardsProvider>
+        <BoardProvider>
+          <ThemeProvider>
+            <SettingsModal open={true} onClose={vi.fn()} />
+          </ThemeProvider>
+        </BoardProvider>
+      </BoardsProvider>,
     );
 
     expect(screen.getByRole("dialog")).toBeInTheDocument();
@@ -94,11 +107,13 @@ describe("SettingsModal", () => {
   it("calls onClose when the close button is clicked", () => {
     const onCloseMock = vi.fn();
     render(
-      <BoardProvider>
-        <ThemeProvider>
-          <SettingsModal open={true} onClose={onCloseMock} />
-        </ThemeProvider>
-      </BoardProvider>,
+      <BoardsProvider>
+        <BoardProvider>
+          <ThemeProvider>
+            <SettingsModal open={true} onClose={onCloseMock} />
+          </ThemeProvider>
+        </BoardProvider>
+      </BoardsProvider>,
     );
 
     fireEvent.click(screen.getByLabelText("Close settings"));
@@ -107,11 +122,13 @@ describe("SettingsModal", () => {
 
   it("does not render when isOpen is false", () => {
     render(
-      <BoardProvider>
-        <ThemeProvider>
-          <SettingsModal open={false} onClose={vi.fn()} />
-        </ThemeProvider>
-      </BoardProvider>,
+      <BoardsProvider>
+        <BoardProvider>
+          <ThemeProvider>
+            <SettingsModal open={false} onClose={vi.fn()} />
+          </ThemeProvider>
+        </BoardProvider>
+      </BoardsProvider>,
     );
 
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();

--- a/src/constants/storage.ts
+++ b/src/constants/storage.ts
@@ -4,8 +4,11 @@
  */
 
 export const STORAGE_KEYS = {
-  /** Board state (columns and cards) */
+  /** Board state (columns and cards) — legacy single-board key */
   BOARD: "kanbeasy:board",
+
+  /** Board index (board list + active ID + global card counter) */
+  BOARD_INDEX: "kanbeasy:boardIndex",
 
   /** Theme preference (light/dark) */
   THEME: "kanbeasy:theme",
@@ -49,3 +52,8 @@ export const STORAGE_KEYS = {
   /** Whether the user has seen the welcome modal */
   HAS_SEEN_WELCOME: "hasSeenWelcome",
 } as const;
+
+/** Returns the localStorage key for a specific board's data */
+export function boardStorageKey(boardId: string): string {
+  return `kanbeasy:board:${boardId}`;
+}

--- a/src/hooks/__tests__/useBoardSwitchKeyboard.test.ts
+++ b/src/hooks/__tests__/useBoardSwitchKeyboard.test.ts
@@ -1,0 +1,182 @@
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { useBoardSwitchKeyboard } from "../useBoardSwitchKeyboard";
+import type { BoardMeta } from "../../boards/types";
+
+function makeBoards(count: number): BoardMeta[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `board-${i}`,
+    title: `Board ${i}`,
+    createdAt: "2025-01-01",
+    updatedAt: "2025-01-01",
+  }));
+}
+
+function fireKey(key: string, mods: Partial<KeyboardEventInit> = {}) {
+  document.dispatchEvent(
+    new KeyboardEvent("keydown", {
+      key,
+      metaKey: true,
+      shiftKey: true,
+      bubbles: true,
+      ...mods,
+    }),
+  );
+}
+
+describe("useBoardSwitchKeyboard", () => {
+  it("switches to next board on Cmd+Shift+]", () => {
+    const switchBoard = vi.fn();
+    const boards = makeBoards(3);
+
+    renderHook(() =>
+      useBoardSwitchKeyboard({
+        boards,
+        activeBoardId: "board-0",
+        switchBoard,
+      }),
+    );
+
+    fireKey("]");
+
+    expect(switchBoard).toHaveBeenCalledWith("board-1");
+  });
+
+  it("switches to previous board on Cmd+Shift+[", () => {
+    const switchBoard = vi.fn();
+    const boards = makeBoards(3);
+
+    renderHook(() =>
+      useBoardSwitchKeyboard({
+        boards,
+        activeBoardId: "board-1",
+        switchBoard,
+      }),
+    );
+
+    fireKey("[");
+
+    expect(switchBoard).toHaveBeenCalledWith("board-0");
+  });
+
+  it("wraps around from last to first board", () => {
+    const switchBoard = vi.fn();
+    const boards = makeBoards(3);
+
+    renderHook(() =>
+      useBoardSwitchKeyboard({
+        boards,
+        activeBoardId: "board-2",
+        switchBoard,
+      }),
+    );
+
+    fireKey("]");
+
+    expect(switchBoard).toHaveBeenCalledWith("board-0");
+  });
+
+  it("wraps around from first to last board", () => {
+    const switchBoard = vi.fn();
+    const boards = makeBoards(3);
+
+    renderHook(() =>
+      useBoardSwitchKeyboard({
+        boards,
+        activeBoardId: "board-0",
+        switchBoard,
+      }),
+    );
+
+    fireKey("[");
+
+    expect(switchBoard).toHaveBeenCalledWith("board-2");
+  });
+
+  it("does not switch when only one board exists", () => {
+    const switchBoard = vi.fn();
+    const boards = makeBoards(1);
+
+    renderHook(() =>
+      useBoardSwitchKeyboard({
+        boards,
+        activeBoardId: "board-0",
+        switchBoard,
+      }),
+    );
+
+    fireKey("]");
+    fireKey("[");
+
+    expect(switchBoard).not.toHaveBeenCalled();
+  });
+
+  it("ignores keys without modifier", () => {
+    const switchBoard = vi.fn();
+    const boards = makeBoards(3);
+
+    renderHook(() =>
+      useBoardSwitchKeyboard({
+        boards,
+        activeBoardId: "board-0",
+        switchBoard,
+      }),
+    );
+
+    fireKey("]", { metaKey: false, ctrlKey: false });
+
+    expect(switchBoard).not.toHaveBeenCalled();
+  });
+
+  it("ignores keys without shift", () => {
+    const switchBoard = vi.fn();
+    const boards = makeBoards(3);
+
+    renderHook(() =>
+      useBoardSwitchKeyboard({
+        boards,
+        activeBoardId: "board-0",
+        switchBoard,
+      }),
+    );
+
+    fireKey("]", { shiftKey: false });
+
+    expect(switchBoard).not.toHaveBeenCalled();
+  });
+
+  it("works with Ctrl modifier (non-Mac)", () => {
+    const switchBoard = vi.fn();
+    const boards = makeBoards(3);
+
+    renderHook(() =>
+      useBoardSwitchKeyboard({
+        boards,
+        activeBoardId: "board-0",
+        switchBoard,
+      }),
+    );
+
+    fireKey("]", { metaKey: false, ctrlKey: true });
+
+    expect(switchBoard).toHaveBeenCalledWith("board-1");
+  });
+
+  it("ignores unrelated keys", () => {
+    const switchBoard = vi.fn();
+    const boards = makeBoards(3);
+
+    renderHook(() =>
+      useBoardSwitchKeyboard({
+        boards,
+        activeBoardId: "board-0",
+        switchBoard,
+      }),
+    );
+
+    fireKey("a");
+    fireKey("z");
+
+    expect(switchBoard).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,3 @@
+export { useBoardSwitchKeyboard } from "./useBoardSwitchKeyboard";
 export { useInlineEdit } from "./useInlineEdit";
 export { useUndoRedoKeyboard } from "./useUndoRedoKeyboard";

--- a/src/hooks/useBoardSwitchKeyboard.ts
+++ b/src/hooks/useBoardSwitchKeyboard.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from "react";
+import type { BoardMeta } from "../boards/types";
+
+type UseBoardSwitchKeyboardOptions = {
+  boards: BoardMeta[];
+  activeBoardId: string;
+  switchBoard: (id: string) => void;
+};
+
+export function useBoardSwitchKeyboard({
+  boards,
+  activeBoardId,
+  switchBoard,
+}: UseBoardSwitchKeyboardOptions) {
+  const ref = useRef({ boards, activeBoardId, switchBoard });
+  ref.current = { boards, activeBoardId, switchBoard };
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      const mod = e.metaKey || e.ctrlKey;
+      if (!mod || !e.shiftKey) return;
+
+      let delta = 0;
+      if (e.key === "[") delta = -1;
+      else if (e.key === "]") delta = 1;
+      else return;
+
+      e.preventDefault();
+      const { boards: b, activeBoardId: active, switchBoard: sw } = ref.current;
+      if (b.length <= 1) return;
+
+      const currentIndex = b.findIndex((board) => board.id === active);
+      const nextIndex = (currentIndex + delta + b.length) % b.length;
+      sw(b[nextIndex].id);
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, []);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,17 +3,20 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
 import { ThemeProvider } from "./theme/ThemeProvider";
+import { BoardsProvider } from "./boards/BoardsProvider";
 import { BoardProvider } from "./board/BoardProvider";
 import { ClipboardProvider } from "./board/ClipboardProvider";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <ThemeProvider>
-      <BoardProvider>
-        <ClipboardProvider>
-          <App />
-        </ClipboardProvider>
-      </BoardProvider>
+      <BoardsProvider>
+        <BoardProvider>
+          <ClipboardProvider>
+            <App />
+          </ClipboardProvider>
+        </BoardProvider>
+      </BoardsProvider>
     </ThemeProvider>
   </StrictMode>,
 );

--- a/src/test/renderApp.tsx
+++ b/src/test/renderApp.tsx
@@ -1,5 +1,6 @@
 import { render } from "@testing-library/react";
 import App from "../App";
+import { BoardsProvider } from "../boards/BoardsProvider";
 import { BoardProvider } from "../board/BoardProvider";
 import { ClipboardProvider } from "../board/ClipboardProvider";
 import { ThemeProvider } from "../theme/ThemeProvider";
@@ -7,11 +8,13 @@ import { ThemeProvider } from "../theme/ThemeProvider";
 export function renderApp() {
   return render(
     <ThemeProvider>
-      <BoardProvider>
-        <ClipboardProvider>
-          <App />
-        </ClipboardProvider>
-      </BoardProvider>
+      <BoardsProvider>
+        <BoardProvider>
+          <ClipboardProvider>
+            <App />
+          </ClipboardProvider>
+        </BoardProvider>
+      </BoardsProvider>
     </ThemeProvider>,
   );
 }

--- a/src/test/renderWithProviders.tsx
+++ b/src/test/renderWithProviders.tsx
@@ -1,9 +1,11 @@
 import * as React from "react";
 import { render, type RenderOptions } from "@testing-library/react";
 import { BoardContext } from "../board/BoardContext";
+import { BoardsContext } from "../boards/BoardsContext";
 import { ClipboardContext } from "../board/ClipboardContext";
 import { ThemeContext } from "../theme/ThemeContext";
 import type { BoardContextValue } from "../board/types";
+import type { BoardsContextValue } from "../boards/types";
 import type { ClipboardContextValue } from "../board/ClipboardContext";
 import type { ThemeContextValue } from "../theme/types";
 
@@ -80,6 +82,30 @@ export function makeBoardContext(
   };
 }
 
+function makeBoardsContext(
+  overrides: Partial<BoardsContextValue> = {},
+): BoardsContextValue {
+  return {
+    boards: [
+      {
+        id: "test-board",
+        title: "Test Board",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+    ],
+    activeBoardId: "test-board",
+    nextCardNumber: 1,
+    createBoard: () => "new-board-id",
+    deleteBoard: noop,
+    renameBoard: noop,
+    switchBoard: noop,
+    duplicateBoard: () => "dup-board-id",
+    setNextCardNumber: noop,
+    ...overrides,
+  };
+}
+
 export function makeClipboardContext(
   overrides: Partial<ClipboardContextValue> = {},
 ): ClipboardContextValue {
@@ -93,6 +119,7 @@ export function makeClipboardContext(
 
 type ProviderOverrides = {
   board?: Partial<BoardContextValue>;
+  boards?: Partial<BoardsContextValue>;
   theme?: Partial<ThemeContextValue>;
   clipboard?: Partial<ClipboardContextValue>;
 };
@@ -103,17 +130,20 @@ export function renderWithProviders(
   renderOptions?: Omit<RenderOptions, "wrapper">,
 ) {
   const board = makeBoardContext(overrides.board);
+  const boards = makeBoardsContext(overrides.boards);
   const theme = makeThemeContext(overrides.theme);
   const clipboard = makeClipboardContext(overrides.clipboard);
 
   const Wrapper = ({ children }: { children: React.ReactNode }) => (
-    <BoardContext.Provider value={board}>
-      <ThemeContext.Provider value={theme}>
-        <ClipboardContext.Provider value={clipboard}>
-          {children}
-        </ClipboardContext.Provider>
-      </ThemeContext.Provider>
-    </BoardContext.Provider>
+    <BoardsContext.Provider value={boards}>
+      <BoardContext.Provider value={board}>
+        <ThemeContext.Provider value={theme}>
+          <ClipboardContext.Provider value={clipboard}>
+            {children}
+          </ClipboardContext.Provider>
+        </ThemeContext.Provider>
+      </BoardContext.Provider>
+    </BoardsContext.Provider>
   );
 
   return render(ui, { wrapper: Wrapper, ...renderOptions });

--- a/src/utils/exportBoard.ts
+++ b/src/utils/exportBoard.ts
@@ -1,5 +1,6 @@
 import { STORAGE_KEYS, boardStorageKey } from "../constants/storage";
 import type { BoardIndex } from "../boards/types";
+import { getFromStorage } from "./storage";
 
 interface ExportData {
   version: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
@@ -25,18 +26,13 @@ function readRaw(key: string): string {
 }
 
 function getActiveBoardStorageKey(): string {
-  const raw = window.localStorage.getItem(STORAGE_KEYS.BOARD_INDEX);
-  if (raw) {
-    try {
-      const index = JSON.parse(raw) as BoardIndex;
-      if (index.activeBoardId) {
-        return boardStorageKey(index.activeBoardId);
-      }
-    } catch {
-      // fall through
-    }
+  const index = getFromStorage<BoardIndex | null>(
+    STORAGE_KEYS.BOARD_INDEX,
+    null,
+  );
+  if (index?.activeBoardId) {
+    return boardStorageKey(index.activeBoardId);
   }
-  // Fallback to legacy key
   return STORAGE_KEYS.BOARD;
 }
 

--- a/src/utils/exportBoard.ts
+++ b/src/utils/exportBoard.ts
@@ -1,4 +1,5 @@
-import { STORAGE_KEYS } from "../constants/storage";
+import { STORAGE_KEYS, boardStorageKey } from "../constants/storage";
+import type { BoardIndex } from "../boards/types";
 
 interface ExportData {
   version: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
@@ -23,8 +24,25 @@ function readRaw(key: string): string {
   return window.localStorage.getItem(key) ?? "";
 }
 
+function getActiveBoardStorageKey(): string {
+  const raw = window.localStorage.getItem(STORAGE_KEYS.BOARD_INDEX);
+  if (raw) {
+    try {
+      const index = JSON.parse(raw) as BoardIndex;
+      if (index.activeBoardId) {
+        return boardStorageKey(index.activeBoardId);
+      }
+    } catch {
+      // fall through
+    }
+  }
+  // Fallback to legacy key
+  return STORAGE_KEYS.BOARD;
+}
+
 function buildExportData(): ExportData {
-  const boardRaw = window.localStorage.getItem(STORAGE_KEYS.BOARD);
+  const storageKey = getActiveBoardStorageKey();
+  const boardRaw = window.localStorage.getItem(storageKey);
   let board: unknown = null;
   if (boardRaw) {
     try {


### PR DESCRIPTION
## Summary

- Add core multi-board infrastructure: create, switch, rename, duplicate, and delete separate kanban boards
- Each board is fully isolated with its own columns, cards, archive, and undo/redo history
- Transparent migration for existing users — single-board data moves to `kanbeasy:board:default` on first load
- Board tab bar below the header with inline rename (double-click), right-click context menu, and keyboard shortcuts (`Cmd+Shift+[`/`]`)

### New files
- `src/boards/` — `BoardsProvider`, `BoardsContext`, `useBoards`, types
- `src/components/BoardTabs.tsx` — tab bar UI
- `src/hooks/useBoardSwitchKeyboard.ts` — keyboard shortcuts
- `src/components/icons/PlusIcon.tsx` — plus icon for new board button

### Key changes
- `BoardProvider` now reads `activeBoardId` from `BoardsContext` and loads/saves per-board
- `useUndoableState` gains a `reset()` method for board switching
- Export reads from the active board's storage key via board index lookup
- Storage keys: `kanbeasy:boardIndex` for the index, `kanbeasy:board:<id>` per board

### Not yet in scope (follow-ups)
- Moving card types to per-board state
- Export format version bump for multi-board export/import
- Board management section in Settings modal
- `Cmd+B` quick board switcher modal

## Test plan

- [x] All 830 unit tests pass (54 new tests added)
- [x] `npm run static-checks` passes (format, lint, knip, typecheck, build, tests)
- [ ] Manual: create multiple boards, switch between them, verify data isolation
- [ ] Manual: rename, duplicate, delete boards via context menu
- [ ] Manual: existing single-board data migrates correctly on first load
- [ ] Manual: keyboard shortcuts Cmd+Shift+[/] cycle through boards
- [ ] E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)